### PR TITLE
Prevent idempotent requests for event triggering.

### DIFF
--- a/src/Spryker/Zed/Oms/Communication/Controller/TriggerController.php
+++ b/src/Spryker/Zed/Oms/Communication/Controller/TriggerController.php
@@ -10,6 +10,7 @@ namespace Spryker\Zed\Oms\Communication\Controller;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Spryker\Zed\Kernel\Communication\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
  * @method \Spryker\Zed\Oms\Business\OmsFacadeInterface getFacade()
@@ -34,7 +35,7 @@ class TriggerController extends AbstractController
     protected const ERROR_INVALID_FORM = 'Form is invalid';
 
     /**
-     * @deprecated use submitTriggerEventForOrderItemsAction instead
+     * @deprecated Use submitTriggerEventForOrderItemsAction() instead.
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
      *
@@ -42,6 +43,11 @@ class TriggerController extends AbstractController
      */
     public function triggerEventForOrderItemsAction(Request $request)
     {
+        trigger_error(
+            "This action is deprecated, please use submitTriggerEventForOrderItemsAction() instead.",
+            E_USER_DEPRECATED
+        );
+
         $redirect = $request->query->get(static::REQUEST_PARAMETER_REDIRECT, static::ROUTE_REDIRECT_DEFAULT);
         $idOrderItems = $this->getRequestIdSalesOrderItems($request);
         if ($idOrderItems === []) {
@@ -82,7 +88,7 @@ class TriggerController extends AbstractController
     }
 
     /**
-     * @deprecated use submitTriggerEventForOrderAction instead
+     * @deprecated Use submitTriggerEventForOrderAction() instead.
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
      *
@@ -90,6 +96,11 @@ class TriggerController extends AbstractController
      */
     public function triggerEventForOrderAction(Request $request)
     {
+        trigger_error(
+            "This action is deprecated, please use submitTriggerEventForOrderAction() instead.",
+            E_USER_DEPRECATED
+        );
+
         $idOrder = $this->castId($request->query->getInt('id-sales-order'));
         $event = $request->query->get('event');
         $redirect = $request->query->get('redirect', '/');
@@ -153,11 +164,17 @@ class TriggerController extends AbstractController
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
      *
+     * @throws \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
+     *
      * @return bool
      */
     protected function isValidPostRequest(Request $request): bool
     {
-        return $request->isMethod(Request::METHOD_POST) && $this->isTriggerFormValid($request);
+        if (!$request->isMethod(Request::METHOD_POST)) {
+            throw new BadRequestHttpException();
+        }
+
+        return $this->isTriggerFormValid($request);
     }
 
     /**


### PR DESCRIPTION
Branch: backport/cc-6261/oms-10.5.0
Ticket: https://spryker.atlassian.net/browse/CC-6261
Target Version: 10.5.0
Release: https://release.spryker.com/release-groups/view/1934

https://release.spryker.com/release/hotfix?pr=https%3A%2F%2Fgithub.com%2Fspryker%2Foms%2Fpull%2F2

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Oms               | minor                 |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module Oms

##### Change log

Bugfixes

- Adjusted event triggering controller actions to prevent idempotent requests.
- Event triggering HTTP-requests must be performed with POST-method.

Adjustments

- Adjusted `TriggerController::triggerEventForOrderAction()` method with error triggering.
- Adjusted `TriggerController::triggerEventForOrderItemsAction()` method with error triggering.
