### PR TITLE
CC-7923 All orders are not processed if only one of them has failed during oms:check-timeout

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
   "license": "proprietary",
   "require": {
     "php": ">=7.1",
+    "spryker/error-handler": "^2.1.0",
     "spryker/graph": "^3.0.0",
     "spryker/gui": "^3.0.0",
     "spryker/kernel": "^3.0.0",

--- a/src/Spryker/Zed/Oms/Business/OrderStateMachine/OrderStateMachine.php
+++ b/src/Spryker/Zed/Oms/Business/OrderStateMachine/OrderStateMachine.php
@@ -13,6 +13,7 @@ use LogicException;
 use Orm\Zed\Oms\Persistence\SpyOmsOrderItemState;
 use Orm\Zed\Oms\Persistence\SpyOmsOrderItemStateQuery;
 use Orm\Zed\Sales\Persistence\SpySalesOrderItem;
+use Spryker\Shared\ErrorHandler\ErrorLogger;
 use Spryker\Zed\Oms\Business\Process\ProcessInterface;
 use Spryker\Zed\Oms\Business\Process\StateInterface;
 use Spryker\Zed\Oms\Business\Util\ReadOnlyArrayObject;
@@ -203,6 +204,9 @@ class OrderStateMachine implements OrderStateMachineInterface
             $this->logSourceState($groupedOrderItems, $log);
 
             $processedOrderItems = $this->runCommand($eventId, $groupedOrderItems, $processes, $data, $log);
+            if ($processedOrderItems === null) {
+                continue;
+            }
             $sourceStateBuffer = $this->updateStateByEvent($eventId, $processedOrderItems, $sourceStateBuffer, $log);
             $this->saveOrderItems($processedOrderItems, $log, $processes, $sourceStateBuffer);
             $allProcessedOrderItems = array_merge($allProcessedOrderItems, $processedOrderItems);
@@ -494,9 +498,9 @@ class OrderStateMachine implements OrderStateMachineInterface
      * @param \Spryker\Zed\Oms\Business\Util\ReadOnlyArrayObject $data
      * @param \Spryker\Zed\Oms\Business\Util\TransitionLogInterface $log
      *
-     * @throws \Exception
+     * @throws \LogicException
      *
-     * @return \Orm\Zed\Sales\Persistence\SpySalesOrderItem[]
+     * @return \Orm\Zed\Sales\Persistence\SpySalesOrderItem[]|null
      */
     protected function runCommand($eventId, array $orderItems, array $processes, ReadOnlyArrayObject $data, TransitionLogInterface $log)
     {
@@ -544,8 +548,9 @@ class OrderStateMachine implements OrderStateMachineInterface
                 $log->setErrorMessage(get_class($e) . ' - ' . $e->getMessage());
                 $log->saveAll();
 
-                if ($type !== self::BY_ITEM) {
-                    throw $e;
+                ErrorLogger::getInstance()->log($e);
+                if ($type === static::BY_ORDER) {
+                    return null; // intercept the processing of a grouped order items for the current order state
                 }
             }
         }

--- a/tests/SprykerTest/Zed/Oms/Business/OmsFacadeTest.php
+++ b/tests/SprykerTest/Zed/Oms/Business/OmsFacadeTest.php
@@ -12,10 +12,16 @@ use DateTime;
 use Generated\Shared\Transfer\StoreTransfer;
 use Orm\Zed\Oms\Persistence\SpyOmsStateMachineLock;
 use Orm\Zed\Oms\Persistence\SpyOmsStateMachineLockQuery;
+use Orm\Zed\Sales\Persistence\SpySalesOrderItemQuery;
 use Orm\Zed\Sales\Persistence\SpySalesOrderQuery;
+use Spryker\Zed\Kernel\Container;
 use Spryker\Zed\Oms\Business\OmsBusinessFactory;
 use Spryker\Zed\Oms\Business\OmsFacade;
+use Spryker\Zed\Oms\Communication\Plugin\Oms\Command\CommandCollectionInterface;
 use Spryker\Zed\Oms\OmsConfig;
+use Spryker\Zed\Oms\OmsDependencyProvider;
+use Spryker\Zed\PropelOrm\Business\Runtime\ActiveQuery\Criteria;
+use SprykerTest\Zed\Oms\Business\OrderStateMachine\Plugin\Fixtures\TestAuthPlugin;
 
 /**
  * Auto-generated group annotations
@@ -166,6 +172,51 @@ class OmsFacadeTest extends Unit
     }
 
     /**
+     * @return void
+     */
+    public function testTriggerEventWillNotThrowAnExceptionWhenExceptionWasThrownDuringOrderItemHandling(): void
+    {
+        //Arrange
+        $testStateMachineProcessName = 'Test02';
+        $omsFacade = $this->createOmsFacadeWithErroredTestStateMachine([$testStateMachineProcessName]);
+        $saveOrderTransfer1 = $this->tester->haveOrder([
+            'unitPrice' => 100,
+            'sumPrice' => 100,
+        ], $testStateMachineProcessName);
+        $saveOrderTransfer2 = $this->tester->haveOrder([
+            'unitPrice' => 100,
+            'sumPrice' => 100,
+        ], $testStateMachineProcessName);
+        $orderItems = SpySalesOrderItemQuery::create()
+            ->filterByFkSalesOrder_In([
+                $saveOrderTransfer1->getIdSalesOrder(),
+                $saveOrderTransfer2->getIdSalesOrder(),
+            ])
+            ->orderByIdSalesOrderItem(Criteria::ASC)
+            ->find();
+        //Act
+        $omsFacade->triggerEvent('authorize', clone $orderItems, []);
+        $processedOrderItems = SpySalesOrderItemQuery::create()
+            ->filterByFkSalesOrder_In([
+                $saveOrderTransfer1->getIdSalesOrder(),
+                $saveOrderTransfer2->getIdSalesOrder(),
+            ])
+            ->orderByIdSalesOrderItem(Criteria::ASC)
+            ->find();
+        //Assert
+        $this->assertEquals(
+            $orderItems->shift()->getFkOmsOrderItemState(),
+            $processedOrderItems->shift()->getFkOmsOrderItemState()
+        );
+        while ($orderItems->count()) {
+            $this->assertNotEquals(
+                $orderItems->shift()->getFkOmsOrderItemState(),
+                $processedOrderItems->shift()->getFkOmsOrderItemState()
+            );
+        }
+    }
+
+    /**
      * @return \Spryker\Zed\Oms\Business\OmsFacadeInterface
      */
     protected function createOmsFacade()
@@ -191,5 +242,28 @@ class OmsFacadeTest extends Unit
         $this->tester->configureTestStateMachine($activeProcesses, $xmlFolder);
 
         return new OmsFacade();
+    }
+
+    /**
+     * @param array $activeProcesses
+     * @param string|null $xmlFolder
+     *
+     * @return \Spryker\Zed\Oms\Business\OmsFacadeInterface
+     */
+    protected function createOmsFacadeWithErroredTestStateMachine(array $activeProcesses = [], ?string $xmlFolder = null): OmsFacadeInterface
+    {
+        $this->tester->configureTestStateMachine($activeProcesses);
+        $omsDependencyProvider = new OmsDependencyProvider();
+        $container = new Container();
+        $container = $omsDependencyProvider->provideBusinessLayerDependencies($container);
+        $container = $omsDependencyProvider->providePersistenceLayerDependencies($container);
+        $container->extend(OmsDependencyProvider::COMMAND_PLUGINS, function (CommandCollectionInterface $commandCollection) {
+            return $commandCollection->add(new TestAuthPlugin(), 'TestPayment/Authorize');
+        });
+        $omsBusinessFactory = new OmsBusinessFactory();
+        $omsBusinessFactory->setContainer($container);
+        $omsFacade = new OmsFacade();
+        $omsFacade->setFactory($omsBusinessFactory);
+        return $omsFacade;
     }
 }

--- a/tests/SprykerTest/Zed/Oms/Business/OmsFacadeTest.php
+++ b/tests/SprykerTest/Zed/Oms/Business/OmsFacadeTest.php
@@ -179,6 +179,7 @@ class OmsFacadeTest extends Unit
         //Arrange
         $testStateMachineProcessName = 'Test02';
         $omsFacade = $this->createOmsFacadeWithErroredTestStateMachine([$testStateMachineProcessName]);
+
         $saveOrderTransfer1 = $this->tester->haveOrder([
             'unitPrice' => 100,
             'sumPrice' => 100,
@@ -187,6 +188,7 @@ class OmsFacadeTest extends Unit
             'unitPrice' => 100,
             'sumPrice' => 100,
         ], $testStateMachineProcessName);
+
         $orderItems = SpySalesOrderItemQuery::create()
             ->filterByFkSalesOrder_In([
                 $saveOrderTransfer1->getIdSalesOrder(),
@@ -194,8 +196,11 @@ class OmsFacadeTest extends Unit
             ])
             ->orderByIdSalesOrderItem(Criteria::ASC)
             ->find();
+
         //Act
         $omsFacade->triggerEvent('authorize', clone $orderItems, []);
+
+        //Assert
         $processedOrderItems = SpySalesOrderItemQuery::create()
             ->filterByFkSalesOrder_In([
                 $saveOrderTransfer1->getIdSalesOrder(),
@@ -203,17 +208,17 @@ class OmsFacadeTest extends Unit
             ])
             ->orderByIdSalesOrderItem(Criteria::ASC)
             ->find();
-        //Assert
+
         $this->assertEquals(
-            $orderItems->shift()->getFkOmsOrderItemState(),
-            $processedOrderItems->shift()->getFkOmsOrderItemState()
+            $orderItems->offsetGet(0)->getFkOmsOrderItemState(),
+            $processedOrderItems->offsetGet(0)->getFkOmsOrderItemState(),
+            'Order item state ID does not equal to an expected value.'
         );
-        while ($orderItems->count()) {
-            $this->assertNotEquals(
-                $orderItems->shift()->getFkOmsOrderItemState(),
-                $processedOrderItems->shift()->getFkOmsOrderItemState()
-            );
-        }
+        $this->assertNotEquals(
+            $orderItems->offsetGet(1)->getFkOmsOrderItemState(),
+            $processedOrderItems->offsetGet(1)->getFkOmsOrderItemState(),
+            'Order item state ID does not equal to an expected value.'
+        );
     }
 
     /**

--- a/tests/SprykerTest/Zed/Oms/Business/OrderStateMachine/Plugin/Fixtures/TestAuthPlugin.php
+++ b/tests/SprykerTest/Zed/Oms/Business/OrderStateMachine/Plugin/Fixtures/TestAuthPlugin.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerTest\Zed\Oms\Business\OrderStateMachine\Plugin\Fixtures;
+
+use Exception;
+use Orm\Zed\Sales\Persistence\SpySalesOrder;
+use Spryker\Zed\Kernel\Communication\AbstractPlugin;
+use Spryker\Zed\Oms\Business\Util\ReadOnlyArrayObject;
+use Spryker\Zed\Oms\Dependency\Plugin\Command\CommandByOrderInterface;
+
+class TestAuthPlugin extends AbstractPlugin implements CommandByOrderInterface
+{
+    /**
+     * @var int
+     */
+    protected static $count = 0;
+
+    /**
+     * @param array $orderItems
+     * @param \Orm\Zed\Sales\Persistence\SpySalesOrder $orderEntity
+     * @param \Spryker\Zed\Oms\Business\Util\ReadOnlyArrayObject $data
+     *
+     * @throws \Exception
+     *
+     * @return array|void
+     */
+    public function run(array $orderItems, SpySalesOrder $orderEntity, ReadOnlyArrayObject $data)
+    {
+        if (self::$count === 0) {
+            self::$count++;
+            throw new Exception('Expected exception.');
+        }
+
+        return [];
+    }
+}

--- a/tests/_data/state-machine/Test02.xml
+++ b/tests/_data/state-machine/Test02.xml
@@ -4,7 +4,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="spryker:oms-01 http://static.spryker.com/oms-01.xsd">
 
-    <process name="Test03" main="true">
+    <process name="Test02" main="true">
 
         <states>
             <state name="new" reserved="true"/>

--- a/tests/_data/state-machine/Test02.xml
+++ b/tests/_data/state-machine/Test02.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0"?>
+<statemachine
+        xmlns="spryker:oms-01"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="spryker:oms-01 http://static.spryker.com/oms-01.xsd">
+
+    <process name="Test03" main="true">
+
+        <states>
+            <state name="new" reserved="true"/>
+            <state name="payment pending" reserved="true"/>
+            <state name="invalid">
+                <flag>exclude from customer</flag>
+            </state>
+            <state name="cancelled">
+                <flag>exclude from customer</flag>
+            </state>
+            <state name="paid"/>
+            <state name="exported" reserved="true"/>
+            <state name="shipped" reserved="true"/>
+            <state name="delivered"/>
+            <state name="closed"/>
+        </states>
+
+        <transitions>
+            <transition happy="true">
+                <source>new</source>
+                <target>payment pending</target>
+                <event>authorize</event>
+            </transition>
+
+            <transition>
+                <source>new</source>
+                <target>invalid</target>
+                <event>authorization-failed</event>
+            </transition>
+
+            <transition>
+                <source>payment pending</source>
+                <target>cancelled</target>
+                <event>pay</event>
+            </transition>
+
+            <transition happy="true">
+                <source>paid</source>
+                <target>exported</target>
+                <event>export</event>
+            </transition>
+
+            <transition happy="true">
+                <source>exported</source>
+                <target>shipped</target>
+                <event>ship</event>
+            </transition>
+
+            <transition happy="true">
+                <source>shipped</source>
+                <target>delivered</target>
+                <event>stock-update</event>
+            </transition>
+
+            <transition happy="true">
+                <source>delivered</source>
+                <target>closed</target>
+                <event>close</event>
+            </transition>
+
+        </transitions>
+
+        <events>
+            <event name="authorize" manual="true" command="TestPayment/Authorize"/>
+            <event name="authorization-failed" manual="true"/>
+            <event name="pay" manual="true" command="TestPayment/Pay"/>
+            <event name="export"  manual="true"/>
+            <event name="ship" manual="true"/>
+            <event name="stock-update" manual="true"/>
+            <event name="close" manual="true" timeout="1 hour"/>
+            <event name="return" manual="true"/>
+        </events>
+    </process>
+
+</statemachine>


### PR DESCRIPTION
- Developer(s): @AsonUnique

- Ticket: https://spryker.atlassian.net/browse/CC-7923

- Version: 8.7.0

- Release Group: https://release.spryker.com/release-groups/view/2395

- Release Overview: https://release.spryker.com/release/pull-request/6677

#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Oms                   | minor                 |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module Oms

##### Change log

Improvements

- Adjusted `OmsFacade::triggerEvent()` and `OmsFacade::triggerEventForOneItem()` facade methods so they will not throw a catched exceptions but will add them to the log.

Adjustments

- Added `ErrorHandler` module to dependencies.