### PR TITLE
Fix typo in check-condition command

### DIFF
--- a/src/Spryker/Zed/Oms/Communication/Console/CheckConditionConsole.php
+++ b/src/Spryker/Zed/Oms/Communication/Console/CheckConditionConsole.php
@@ -39,8 +39,8 @@ class CheckConditionConsole extends Console
         $this
             ->setName(static::COMMAND_NAME)
             ->setDescription(static::COMMAND_DESCRIPTION)
-            ->addOption(static::OPTION_STORE_NAME, static::OPTION_STORE_NAME_SHORT, InputOption::VALUE_REQUIRED, 'Defines the store name for which order item timeouts should be checked.')
-            ->addOption(static::OPTION_LIMIT, static::OPTION_LIMIT_SHORT, InputOption::VALUE_REQUIRED, 'Defines the amount of orders for which the order item timeouts should be checked.')
+            ->addOption(static::OPTION_STORE_NAME, static::OPTION_STORE_NAME_SHORT, InputOption::VALUE_REQUIRED, 'Defines the store name for which order item conditions should be checked.')
+            ->addOption(static::OPTION_LIMIT, static::OPTION_LIMIT_SHORT, InputOption::VALUE_REQUIRED, 'Defines the amount of orders for which the order item conditions should be checked.')
             ->addOption(static::OPTION_PROCESSOR_ID, static::OPTION_PROCESSOR_ID_SHORT, InputOption::VALUE_OPTIONAL, 'Defines coma-separated list of the processor identifiers in a multi-thread OMS setup.');
 
         parent::configure();


### PR DESCRIPTION
## PR Description

I fixed a copy-paste typo in the `oms:check-condition` command.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
