### PR TITLE
Add flag enumeration "not auth"

### DIFF
--- a/data/definition/oms-01.xsd
+++ b/data/definition/oms-01.xsd
@@ -39,6 +39,7 @@
                     <xsd:restriction base="xsd:string">
                         <xsd:enumeration value="exclude from customer"/>
                         <xsd:enumeration value="exclude from invoice"/>
+                        <xsd:enumeration value="not auth"/>
                         <xsd:enumeration value="ready for invoice"/>
                         <xsd:enumeration value="waiting for export"/>
                         <xsd:enumeration value="cancellable"/>


### PR DESCRIPTION
## 📚  Description

Currently, when using the "not auth" flag in any OMS state, the IDE doesn't recognise it, because it's not part of the `xsd:enumeration` from the `oms-01.xsd`. 

This flag is actually used in the **AmazonPay PaymentMethod**, see: https://github.com/spryker-eco/amazon-pay/blob/master/config/Zed/Oms/AmazonPayAsync01.xml#L17

## 🖼️ Screenshots

### BEFORE
<img width="441" alt="Screenshot 2022-12-01 at 15 27 05" src="https://user-images.githubusercontent.com/5256287/205078650-a1cfbb63-1554-435f-b2bf-9335945284d1.png">

### AFTER
<img width="410" alt="Screenshot 2022-12-01 at 15 27 35" src="https://user-images.githubusercontent.com/5256287/205078661-2631c070-6635-4fab-a3fb-fc3a3b89bd14.png">



## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
